### PR TITLE
+ Make configure support --with-ssl option.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -50,12 +50,6 @@ AC_PATH_PROG(CP, cp)
     [fi]
 [fi]
 
-[if test x"$SSL" != "x"; then]
-    CPPFLAGS="$CPPFLAGS -I$SSL/include"
-    LDFLAGS="$LDFLAGS -L$SSL/lib"
-    AC_MSG_NOTICE([Using OpenSSL from "--with-ssl=$SSL"])
-[fi]
-
 # Add GCC warning flags
 [if test x"$GCC" = "xyes"; then
     GCC_WARN_FLAGS="${GCC_WARN_FLAGS} -Wall -Waggregate-return -Wcast-align -Wchar-subscripts -Wcomment -Wformat \
@@ -68,6 +62,10 @@ AC_SUBST(GCC_WARN_FLAGS)
 AC_SUBST(CFLAGS)
 
 # Check for required libraries
+[if test x"$SSL" != "x"; then]
+    PKG_CONFIG_PATH="$SSL/lib/pkgconfig:$PKG_CONFIG_PATH"
+    AC_MSG_NOTICE([PKG_CONFIG_PATH prefixed with "$SSL/lib/pkgconfig"])
+[fi]
 PKG_CHECK_MODULES([OPENSSL], [openssl])
 CFLAGS="${CFLAGS} ${OPENSSL_CFLAGS}"
 LIBS="${LIBS} ${OPENSSL_LIBS}"

--- a/configure.ac
+++ b/configure.ac
@@ -29,6 +29,11 @@ AC_PROG_MAKE_SET
 AC_ARG_WITH(apxs,
     AS_HELP_STRING([--with-apxs=PATH], [PATH is the pathname of the Apache tool [apxs]]),
     [APXS="$with_apxs"])
+
+AC_ARG_WITH(ssl,
+    AS_HELP_STRING([--with-ssl=PATH], [Specify prefix of OpenSSL installation]),
+    [SSL="$with_ssl"])
+
 AC_ARG_ENABLE(Werror,
     AS_HELP_STRING([--enable-Werror], [enable compilation with -Werror flag (default NO)]),
     [test x"$enableval" = "xyes" && GCC_WARN_FLAGS="${GCC_WARN_FLAGS} -Werror"])
@@ -43,6 +48,12 @@ AC_PATH_PROG(CP, cp)
     [if test x"$APXS" = "x" ; then]
         AC_MSG_ERROR([apxs utility not found; specify using "--with-apxs=PATH"])
     [fi]
+[fi]
+
+[if test x"$SSL" != "x"; then]
+    CPPFLAGS="$CPPFLAGS -I$SSL/include"
+    LDFLAGS="$LDFLAGS -L$SSL/lib"
+    AC_MSG_NOTICE([Using OpenSSL from "--with-ssl=$SSL"])
 [fi]
 
 # Add GCC warning flags


### PR DESCRIPTION
For environments where this module is compiled against a specific, non-OS wide, version of OpenSSL, this PR simplifies `configure`.
```
CPPFLAGS="-I/OPENSSL_PATH/include" \
LDFLAGS="-L/OPENSSL_PATH/lib" \
./configure
```
Now becomes
```
./configure --with-ssl=/OPENSSL_PATH
```
When `--with-ssl` option is not specified, the behavior remains the same.
